### PR TITLE
Fix AM/PM time

### DIFF
--- a/main.lua
+++ b/main.lua
@@ -1699,7 +1699,7 @@ function drawBottomBar()
         end
         local hour = tostring(t["hour"])
         if not playdate.shouldDisplay24HourTime() then
-            if t["hour"] > 12 then
+            if t["hour"] >= 12 then
                 hour = tostring(t["hour"]-12)
                 min = min .. " PM"
             else


### PR DESCRIPTION
I changed t["hour"] > 12 to t["hour"] >= 12 because the time was showing, as an example, "12:30 AM" when it was actually half past noon (12:30 PM).